### PR TITLE
Refactor consumer configs

### DIFF
--- a/SharpGen.Interactive/CodeGenApp.cs
+++ b/SharpGen.Interactive/CodeGenApp.cs
@@ -353,11 +353,9 @@ namespace SharpGen.Interactive
         {
             var headerGenerator = new CppHeaderGenerator(Logger, _isAssemblyNew, IntermediateOutputPath);
 
-            var (cppHeadersUpdated, cppConsumerConfig) = headerGenerator.GenerateCppHeaders(Config, configsWithIncludes, filesWithExtensions);
+            var (cppHeadersUpdated, prolog) = headerGenerator.GenerateCppHeaders(Config, configsWithIncludes, filesWithExtensions);
 
-            consumerConfig.IncludeProlog.AddRange(cppConsumerConfig.IncludeProlog);
-            consumerConfig.IncludeDirs.AddRange(cppConsumerConfig.IncludeDirs);
-            consumerConfig.Includes.AddRange(cppConsumerConfig.Includes);
+            consumerConfig.IncludeProlog.Add(prolog);
             return cppHeadersUpdated;
         }
 

--- a/SharpGenTools.Sdk/SharpGenTools.Sdk.props
+++ b/SharpGenTools.Sdk/SharpGenTools.Sdk.props
@@ -1,5 +1,6 @@
 ﻿<Project>
   <PropertyGroup>
+    <SharpGenGenerateConsumerBindMapping Condition="'$(SharpGenGenerateConsumerBindMapping)' == ''">true</SharpGenGenerateConsumerBindMapping>
     <SharpGenGenerateDoc Condition="'$(SharpGenGenerateDoc)' == ''">false</SharpGenGenerateDoc>
     <SharpGenGlobalNamespace Condition="'$(SharpGenGlobalNamespace)' == ''">SharpGen.Runtime</SharpGenGlobalNamespace>
     <CastXmlPath Condition="'$(CastXmlPath)' == ''">$(MSBuildThisFileDirectory)../tools/CastXML/bin/castxml.exe</CastXmlPath>

--- a/SharpGenTools.Sdk/SharpGenTools.Sdk.targets
+++ b/SharpGenTools.Sdk/SharpGenTools.Sdk.targets
@@ -37,7 +37,7 @@
       Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework); $(GenerateConsumerBindMappingFilePlaceholderProperty)"
       ContinueOnError="$(ContinueOnError)"
       RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
-      <Output TaskParameter="TargetOutputs" ItemName="SharpGenMapping" />
+      <Output TaskParameter="TargetOutputs" ItemName="SharpGenConsumerMapping" />
     </MSBuild>
   </Target>
 
@@ -50,7 +50,7 @@
         <PackagePath>build/$(TargetFramework);buildMultiTargeting/$(TargetFramework)</PackagePath>
         <Pack>true</Pack>
       </TfmConsumerProps>
-      <SharpGenConsumerBindMappingFile Include="$(MSBuildProjectDirectory)/$(IntermediateOutputPath)SharpGen/$(SharpGenConsumerBindMappingConfigId).BindMapping.xml">
+      <SharpGenConsumerBindMappingFile Condition="'$(SharpGenGenerateConsumerBindMapping)' == 'true'" Include="$(MSBuildProjectDirectory)/$(IntermediateOutputPath)SharpGen/$(SharpGenConsumerBindMappingConfigId).BindMapping.xml">
         <PackagePath>build/$(TargetFramework);buildMultiTargeting/$(TargetFramework)</PackagePath>
         <Pack>true</Pack>
       </SharpGenConsumerBindMappingFile>
@@ -61,6 +61,7 @@
     Name="GenerateTfmSpecificConsumerProps"
     DependsOnTargets="GenerateConsumerBindMappingFile"
     Outputs="@(TfmConsumerProps)"
+     Condition="'$(SharpGenGenerateConsumerBindMapping)' == 'true'"
   >
     <PropertyGroup>
       <EmbeddedConsumerProp>$</EmbeddedConsumerProp>
@@ -68,7 +69,7 @@
     <ItemGroup>
       <TfmConsumerPropsLines Include="&lt;Project&gt;" />
       <TfmConsumerPropsLines Include="&lt;ItemGroup&gt;" />
-      <TfmConsumerPropsLines Include='&lt;SharpGenMapping Include=&quot;$(EmbeddedConsumerProp)(MSBuildThisFileDirectory)/$(SharpGenConsumerBindMappingConfigId).BindMapping.xml&quot;/&gt;' />
+      <TfmConsumerPropsLines Include='&lt;SharpGenConsumerMapping Include=&quot;$(EmbeddedConsumerProp)(MSBuildThisFileDirectory)/$(SharpGenConsumerBindMappingConfigId).BindMapping.xml&quot;/&gt;' />
       <TfmConsumerPropsLines Include="&lt;/ItemGroup&gt;" />
       <TfmConsumerPropsLines Include="&lt;/Project&gt;" />
     </ItemGroup>
@@ -91,6 +92,7 @@
                       AddGeneratedCSharpFilesToCompilation;
                       UpdateSdkAssemblyCheckFile;
                       GenerateConsumerBindMappingFile"
+    Condition="'@(SharpGenMapping)' != ''"
     />
 
   <Target Name="CheckIfPackageNew"
@@ -108,7 +110,7 @@
   <Target
     Name="PrepareCppGeneration">
     <GetGeneratedHeaderNames
-      ConfigFiles="@(SharpGenMapping)"
+      ConfigFiles="@(SharpGenMapping);@(SharpGenConsumerMapping)"
       Macros="$(SharpGenMacros)"
       OutputPath="$(SharpGenIntermediateDir)">
       <Output TaskParameter="Headers" ItemName="Headers" />
@@ -118,11 +120,11 @@
 
   <Target
     Name="GenerateHeaders"
-    DependsOnTargets="PrepareCppGeneration"
-    Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping)"
+    DependsOnTargets="PrepareCppGeneration;GetMappingsFromProjectReferences"
+    Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping);@(SharpGenConsumerMapping)"
     Outputs="@(Headers);@(CppConsumerConfig)">
     <GenerateHeaders
-      ConfigFiles="@(SharpGenMapping)"
+      ConfigFiles="@(SharpGenMapping);@(SharpGenConsumerMapping)"
       Macros="$(SharpGenMacros)"
       HeaderFiles="@(Headers)"
       ExtensionHeaders="@(ExtensionHeaders)"
@@ -136,10 +138,10 @@
   <Target
     Name="GenerateExtensionHeaders"
     DependsOnTargets="PrepareCppGeneration;GenerateHeaders"
-    Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping);@(Headers)"
+    Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping);@(SharpGenConsumerMapping);@(Headers)"
     Outputs="@(ExtensionHeaders);@(PartialCppModule)">
     <GenerateExtensionHeaders
-      ConfigFiles="@(SharpGenMapping)"
+      ConfigFiles="@(SharpGenMapping);@(SharpGenConsumerMapping)"
       Macros="$(SharpGenMacros)"
       ExtensionHeaders="@(ExtensionHeaders)"
       CastXmlExecutablePath="$(CastXmlPath)"
@@ -152,10 +154,10 @@
   <Target
     Name="ParseCPlusPlus"
     DependsOnTargets="GenerateHeaders;GenerateExtensionHeaders"
-    Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping);@(PartialCppModule)"
+    Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping);@(SharpGenConsumerMapping);@(PartialCppModule)"
     Outputs="@(ParsedCppModule)">
     <ParseCPlusPlus
-      ConfigFiles="@(SharpGenMapping)"
+      ConfigFiles="@(SharpGenMapping);@(SharpGenConsumerMapping)"
       Macros="$(SharpGenMacros)"
       CastXmlExecutablePath="$(CastXmlPath)"
       OutputPath="$(MSBuildProjectDirectory)/$(SharpGenIntermediateDir)"
@@ -184,11 +186,12 @@
   <Target
     Name="MapCppToCSharp"
     DependsOnTargets="ParseCPlusPlus;GenerateDocumentation"
-    Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping);@(FullCppModule);@(CppConsumerConfig)"
+    Inputs="@(SharpGenSdkAssembly);@(SharpGenMapping);@(FullCppModule);@(CppConsumerConfig);@(SharpGenConsumerMapping)"
     Outputs="@(CSharpModel);@(DocLinksCache);@(SharpGenConsumerBindMapping)">
     <TransformCppToCSharp
-      ConfigFiles="@(SharpGenMapping)"
+      ConfigFiles="@(SharpGenMapping);@(SharpGenConsumerMapping)"
       Macros="$(SharpGenMacros)"
+      GenerateConsumerConfig="$(SharpGenGenerateConsumerBindMapping)"
       ConsumerBindMappingConfigId="$(SharpGenConsumerBindMappingConfigId)"
       FullCppModule="@(FullCppModule)"
       CppConsumerConfigCache="@(CppConsumerConfig)"
@@ -254,7 +257,6 @@
   <Target
     Name="GenerateConsumerBindMappingFile"
     DependsOnTargets="MapCppToCSharp"
-    Inputs="@(SharpGenMapping)"
     Outputs="@(SharpGenConsumerBindMappingFile)"
   />
   

--- a/SharpGenTools.Sdk/Tasks/GenerateHeaders.cs
+++ b/SharpGenTools.Sdk/Tasks/GenerateHeaders.cs
@@ -51,11 +51,19 @@ namespace SharpGenTools.Sdk.Tasks
                 configsWithExtensions.Add(file.GetMetadata("ConfigId"));
             }
 
-            var (updatedConfigs, consumerCppConfig) = cppHeaderGenerator.GenerateCppHeaders(config, configsWithHeaders, configsWithExtensions);
+            var (updatedConfigs, prolog) = cppHeaderGenerator.GenerateCppHeaders(config, configsWithHeaders, configsWithExtensions);
 
-            consumerCppConfig.Id = "ConsumerCppConfigCache";
+            var consumerConfig = new ConfigFile
+            {
+                Id = "CppConsumerConfig",
+                IncludeProlog =
+                {
+                    prolog
+                }
 
-            consumerCppConfig.Write(CppConsumerConfigCache.ItemSpec);
+            };
+
+            consumerConfig.Write(CppConsumerConfigCache.ItemSpec);
 
             var updatedConfigFiles = new List<ITaskItem>();
 

--- a/SharpGenTools.Sdk/Tasks/TransformCppToCSharp.cs
+++ b/SharpGenTools.Sdk/Tasks/TransformCppToCSharp.cs
@@ -35,6 +35,8 @@ namespace SharpGenTools.Sdk.Tasks
         [Required]
         public ITaskItem DocLinksCache { get; set; }
 
+        public bool GenerateConsumerConfig { get; set; }
+
         protected override bool Execute(ConfigFile config)
         {
             var group = CppModule.Read(FullCppModule.ItemSpec);
@@ -72,7 +74,10 @@ namespace SharpGenTools.Sdk.Tasks
             consumerConfig.Bindings.AddRange(bindings);
             consumerConfig.Extension.AddRange(generatedDefines);
 
-            GenerateConfigForConsumers(consumerConfig);
+            if (GenerateConsumerConfig)
+            {
+                GenerateConfigForConsumers(consumerConfig); 
+            }
 
             SaveDocLinks(docLinker);
 


### PR DESCRIPTION
Don't flow includes or include dirs. Only generate code if there exists a non-consumer config.