### PR TITLE
Refactor doc providers to be async and share a standardized cache.

### DIFF
--- a/SharpGen.Interactive/CodeGenApp.cs
+++ b/SharpGen.Interactive/CodeGenApp.cs
@@ -32,6 +32,7 @@ using SharpGen.Transform;
 using SharpGen.CppModel;
 using SharpGen.Doc;
 using System.Xml;
+using System.Threading.Tasks;
 
 namespace SharpGen.Interactive
 {
@@ -99,6 +100,8 @@ namespace SharpGen.Interactive
 
         public GlobalNamespaceProvider GlobalNamespace { get; set; }
         public Dictionary<string, XmlDocument> ExternalDocumentation { get; set; } = new Dictionary<string, XmlDocument>();
+
+        public DocItemCache DocumentationCache {get; set;} = new DocItemCache();
 
         private string _thisAssemblyPath;
         private bool _isAssemblyNew;
@@ -212,7 +215,7 @@ namespace SharpGen.Interactive
 
                     if (IsGeneratingDoc)
                     {
-                        ApplyDocumentation(group);
+                        ApplyDocumentation(DocumentationCache, group);
                     }
                 }
                 else
@@ -393,7 +396,7 @@ namespace SharpGen.Interactive
         /// <summary>
         /// Apply documentation from an external provider. This is optional.
         /// </summary>
-        private CppModule ApplyDocumentation(CppModule group)
+        private Task<CppModule> ApplyDocumentation(DocItemCache cache, CppModule group)
         {
             // Use default MSDN doc provider
             IDocProvider docProvider = new MsdnProvider(Logger);
@@ -422,7 +425,7 @@ namespace SharpGen.Interactive
             }
 
             Logger.Progress(20, "Applying C++ documentation");
-            return docProvider.ApplyDocumentation(group);
+            return docProvider.ApplyDocumentation(cache, group);
         }
     }
 }

--- a/SharpGen/Doc/IDocProvider.cs
+++ b/SharpGen/Doc/IDocProvider.cs
@@ -17,6 +17,8 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+using System.Threading.Tasks;
+
 namespace SharpGen.Doc
 {
     /// <summary>
@@ -29,24 +31,10 @@ namespace SharpGen.Doc
     public interface IDocProvider
     {
         /// <summary>
-        /// Begins the process of the documentation provider
-        /// </summary>
-        void Begin();
-
-        /// <summary>
         /// Finds the documentation for a particular C++ item.
         /// </summary>
         /// <param name="fullName">The full name. for top level elements (like struct, interfaces, enums, functions), It's the name itself of the element. For interface methods, the name is passed like this "IMyInterface::MyMethod".</param>
         /// <returns></returns>
-        DocItem FindDocumentation(string fullName);
-
-        /// <summary>
-        // Ends the process of the documentation provider
-        /// </summary>
-        void End();
-
-        string OutputPath { get; set; }
-
-        bool ShadowCopy { get; set; }
+        Task<DocItem> FindDocumentationAsync(string fullName);
     }
 }

--- a/SharpGen/Utilities.cs
+++ b/SharpGen/Utilities.cs
@@ -62,19 +62,5 @@ namespace SharpGen
 
             return val;
         }
-        
-		/// <summary>
-		/// Determines whether a string contains a given C++ identifier.
-		/// </summary>
-		/// <param name="str">The string to search.</param>
-		/// <param name="identifier">The C++ identifier to search for.</param>
-		/// <returns></returns>
-		public static bool ContainsCppIdentifier(string str, string identifier)
-		{
-			if (string.IsNullOrEmpty(str))
-				return string.IsNullOrEmpty(identifier);
-
-			return Regex.IsMatch(str, string.Format(@"\b{0}\b", Regex.Escape(identifier)), RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
-		}
     }
 }

--- a/SharpGenTools.Sdk/SharpGenTools.Sdk.targets
+++ b/SharpGenTools.Sdk/SharpGenTools.Sdk.targets
@@ -16,6 +16,7 @@
     <CppConsumerConfig Include="$(SharpGenIntermediateDir)CppConsumerConfig.xml" />
     <PartialCppModule Include="$(SharpGenIntermediateDir)PartialCppModule.xml" />
     <ParsedCppModule Include="$(SharpGenIntermediateDir)ParsedCpp.xml" />
+    <SharpGenDocumentationCache Include="$(SharpGenDocumentationOutputDir)DocumentationCache.xml" />
     <FullCppModule Condition="'$(SharpGenGenerateDoc)' != 'true'" Include="@(ParsedCppModule)" />
     <FullCppModule Condition="'$(SharpGenGenerateDoc)' == 'true'" Include="$(SharpGenIntermediateDir)CppModel.xml" />
   </ItemGroup>
@@ -174,14 +175,13 @@
   <Target Name="GenerateDocumentation"
           DependsOnTargets="ParseCPlusPlus"
           Condition="'$(SharpGenGenerateDoc)' == 'true' and '@(SharpGenMapping)' != ''"
-          Inputs="@(ParsedCppModule)"
+          Inputs="@(ParsedCppModule);@(SharpGenDocumentationCache);$(SharpGenDocProviderAssemblyPath)"
           Outputs="@(FullCppModule)">
     <DocumentCppModule
       DocProviderAssemblyPath="$(SharpGenDocProviderAssemblyPath)"
       ParsedCppModule="@(ParsedCppModule)"
       DocumentedCppModule="@(FullCppModule)"
-      OutputPath="$(SharpGenDocumentationOutputDir)"
-      ShadowCopy="$(ShadowCopyDocumentationOutput)"
+      DocumentationCache="@(SharpGenDocumentationCache)"
     />
   </Target>
 


### PR DESCRIPTION
This allows doc providers that pull documentation from the network to parallelize their requests. Additionally, this generalizes the cache for all doc providers and makes it plaintext so git can track changes as diffs if consumers choose to commit the cache.

This also refactors away repeated code.
