### PR TITLE
Don't associate a shadow with a GUID if that GUID already has a shadow.

### DIFF
--- a/SharpGen.Runtime.UnitTests/CppObjectTests.cs
+++ b/SharpGen.Runtime.UnitTests/CppObjectTests.cs
@@ -15,5 +15,15 @@ namespace SharpGen.Runtime.UnitTests
                 Assert.NotEqual(IntPtr.Zero, CppObject.ToCallbackPtr<ICallback>(callback));
             }
         }
+
+        [Fact]
+        public void GetCallbackPtrForClassWithMultipleInheritenceShouldReturnPointer()
+        {
+            using (var callback = new Callback2Impl())
+            {
+                Assert.NotEqual(IntPtr.Zero, CppObject.ToCallbackPtr<ICallback>(callback));
+                Assert.NotEqual(IntPtr.Zero, CppObject.ToCallbackPtr<ICallback2>(callback));
+            }
+        }
     }
 }

--- a/SharpGen.Runtime.UnitTests/ICallback.cs
+++ b/SharpGen.Runtime.UnitTests/ICallback.cs
@@ -41,4 +41,41 @@ namespace SharpGen.Runtime.UnitTests
 
         protected override CppObjectVtbl Vtbl { get; } = new CallbackVbtl(0);
     }
+
+    [Shadow(typeof(Callback2Shadow))]
+    interface ICallback2: ICallback
+    {
+        int Decrement(int param);
+    }
+
+    class Callback2Shadow : CppObjectShadow
+    {
+        public class Callback2Vbtl : CallbackShadow.CallbackVbtl
+        {
+            public Callback2Vbtl(int numberOfCallbackMethods) : base(numberOfCallbackMethods + 1)
+            {
+                AddMethod(new DecrementDelegate(DecrementImpl));
+            }
+
+            [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+            public delegate int DecrementDelegate(IntPtr thisObj, int param);
+
+            private static int DecrementImpl(IntPtr thisObj, int param)
+            {
+                var shadow = ToShadow<CallbackShadow>(thisObj);
+                var callback = (ICallback)shadow.Callback;
+                return callback.Increment(param);
+            }
+        }
+
+        protected override CppObjectVtbl Vtbl { get; } = new Callback2Vbtl(0);
+    }
+
+    class Callback2Impl : CallbackImpl, ICallback, ICallback2
+    {
+        public int Decrement(int param)
+        {
+            return param - 1;
+        }
+    }
 }

--- a/SharpGen.Runtime/ShadowContainer.cs
+++ b/SharpGen.Runtime/ShadowContainer.cs
@@ -69,8 +69,14 @@ namespace SharpGen.Runtime
 
                 foreach (var inheritInterface in inheritList)
                 {
+                    // If there isn't a Shadow attribute then this isn't a native interface.
                     var inheritShadowAttribute = ShadowAttribute.Get(inheritInterface);
                     if (inheritShadowAttribute == null)
+                        continue;
+
+                    // If we have the same GUID as an already added interface,
+                    // then there's already an accurate shadow for it, so we have nothing to do.
+                    if (guidToShadow.ContainsKey(inheritInterface.GetTypeInfo().GUID))
                         continue;
 
                     // Use same shadow as derived


### PR DESCRIPTION
Fix #53.